### PR TITLE
feat: add na-chain-groups utility for quick NA chain contact detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,7 @@ Splits a multi-model PDB or mmCIF file (e.g. NMR ensembles) into one file per mo
 ### `quick-filter`
 
 Filters atoms from a PDB/mmCIF file while preserving non-atom records (headers, ANISOU, etc.). `--mode` picks `nucleic-acid` (default) or `protein`; `--keep-ligands`/`--keep-waters`/`--keep-ions` retain those classes; `--altloc`, `--chains`, and `--model` further restrict output. Prints filtered content to stdout.
+
+### `na-chain-groups`
+
+Quickly groups nucleic-acid chains by spatial proximity. Builds a KD-tree from C1' atoms (one per nucleotide) and merges chains whose atoms are within a distance threshold (default 15 Å). Outputs JSON: single file → `[["A","B"],["C"]]`; multiple files → `{"file": [["A","B"],...]}`. Accepts multiple paths as args or reads from stdin. `--threshold`, `--atom`, and `--model` are configurable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "RNApolis"
-version = "0.16.9"
+version = "0.16.10"
 description = "A Python library containing RNA-related bioinformatics functions and classes"
 authors = [{ name = "Tomasz Zok", email = "tomasz.zok@cs.put.poznan.pl" }]
 readme = "README.md"
@@ -73,3 +73,4 @@ rfam-folder = "rnapolis.rfam_folder:main"
 unifier = "rnapolis.unifier:main"
 splitter = "rnapolis.splitter:main"
 quick-filter = "rnapolis.quick_filter:main"
+na-chain-groups = "rnapolis.chain_groups:main"

--- a/src/rnapolis/chain_groups.py
+++ b/src/rnapolis/chain_groups.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Quickly group nucleic-acid chains by spatial proximity.
+
+Parses a PDB or mmCIF file, extracts a single representative atom per
+nucleotide (C1' by default), builds a KD-tree and uses a distance
+threshold to decide which chains are in contact.  Chains that share at
+least one atom-atom contact below the threshold are placed in the same
+group via union-find.
+
+This is intentionally a fast heuristic -- no Residue/Structure objects
+are constructed, altloc filtering is skipped (duplicate points are
+harmless), and only one atom per nucleotide is considered.
+"""
+
+import argparse
+import io
+import sys
+from typing import IO, List, Optional, Set, Union
+
+import numpy as np
+import orjson
+import pandas as pd
+from scipy.spatial import KDTree
+
+from rnapolis.parser import is_cif
+from rnapolis.parser_v2 import parse_cif_atoms, parse_pdb_atoms
+from rnapolis.util import handle_input_file
+
+DEFAULT_ATOM_NAME = "C1'"
+DEFAULT_DISTANCE_THRESHOLD = 15.0
+
+
+def _resolve_columns(fmt: str, columns: pd.Index) -> dict[str, str]:
+    """Map semantic column names to actual DataFrame columns for the given format."""
+    resolved: dict[str, str] = {}
+    specs = {
+        "atom_name": (("auth_atom_id", "label_atom_id") if fmt == "mmCIF" else "name"),
+        "chain_id": (
+            ("auth_asym_id", "label_asym_id") if fmt == "mmCIF" else "chainID"
+        ),
+        "x": "Cartn_x" if fmt == "mmCIF" else "x",
+        "y": "Cartn_y" if fmt == "mmCIF" else "y",
+        "z": "Cartn_z" if fmt == "mmCIF" else "z",
+        "model": "pdbx_PDB_model_num" if fmt == "mmCIF" else "model",
+    }
+    for key, spec in specs.items():
+        if isinstance(spec, tuple):
+            for col in spec:
+                if col in columns:
+                    resolved[key] = col
+                    break
+        else:
+            if spec in columns:
+                resolved[key] = spec
+    return resolved
+
+
+def _extract_c1_atoms(
+    atoms: pd.DataFrame,
+    atom_name: str,
+    model: Optional[int],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Filter to representative atoms in one model; return (chains, coords).
+
+    Returns two arrays: ``chains`` (str, shape N) and ``coords``
+    (float64, shape N×3).
+    """
+    if atoms.empty:
+        return np.array([], dtype=object), np.empty((0, 3), dtype=float)
+
+    fmt = atoms.attrs.get("format", "PDB")
+    cols = _resolve_columns(fmt, atoms.columns)
+    atom_col = cols.get("atom_name")
+    chain_col = cols.get("chain_id")
+    model_col = cols.get("model")
+    if atom_col is None or chain_col is None:
+        return np.array([], dtype=object), np.empty((0, 3), dtype=float)
+
+    mask = atoms[atom_col].astype(str) == atom_name
+    filtered = atoms[mask]
+
+    if model_col and model_col in filtered.columns and not filtered.empty:
+        if model is None:
+            first_model = filtered[model_col].dropna().min()
+            filtered = filtered[filtered[model_col] == first_model]
+        else:
+            filtered = filtered[filtered[model_col] == model]
+
+    if filtered.empty:
+        return np.array([], dtype=object), np.empty((0, 3), dtype=float)
+
+    chains = filtered[chain_col].astype(str).to_numpy()
+    coords = filtered[[cols["x"], cols["y"], cols["z"]]].to_numpy(dtype=float)
+
+    return chains, coords
+
+
+def _union_find(chains: np.ndarray, pairs: Set[tuple[int, int]]) -> List[Set[str]]:
+    """Group chains into connected components using union-find."""
+    unique_chains = set(chains.tolist())
+    parent: dict[str, str] = {c: c for c in unique_chains}
+
+    def find(x: str) -> str:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(x: str, y: str) -> None:
+        rx, ry = find(x), find(y)
+        if rx != ry:
+            parent[rx] = ry
+
+    for i, j in pairs:
+        ci, cj = chains[i], chains[j]
+        if ci != cj:
+            union(ci, cj)
+
+    groups: dict[str, Set[str]] = {}
+    for c in unique_chains:
+        root = find(c)
+        groups.setdefault(root, set()).add(c)
+
+    return sorted(groups.values(), key=lambda g: sorted(g))
+
+
+def find_na_chain_groups(
+    content: Union[str, IO[str]],
+    distance_threshold: float = DEFAULT_DISTANCE_THRESHOLD,
+    atom_name: str = DEFAULT_ATOM_NAME,
+    model: Optional[int] = None,
+) -> List[Set[str]]:
+    """Find groups of nucleic-acid chains in contact within a structure.
+
+    Parameters
+    ----------
+    content:
+        PDB or mmCIF content as a string or file-like object.
+    distance_threshold:
+        Maximum distance (in Angstroms) between two representative atoms
+        for their chains to be considered in contact.
+    atom_name:
+        Atom name to use as representative (default ``"C1'"``).  Must be
+        a sugar/base atom present once per nucleotide and absent from
+        non-nucleic-acid residues.
+    model:
+        Model number to analyse.  If ``None``, the first model
+        containing the representative atom is used.
+
+    Returns
+    -------
+    list[set[str]]
+        Sorted list of chain groups.  Each group is a set of chain IDs
+        that are in spatial contact.  Isolated chains appear as
+        singletons.
+    """
+    if isinstance(content, str):
+        content_str = content
+    else:
+        content.seek(0)
+        content_str = content.read()
+        if isinstance(content_str, bytes):
+            content_str = content_str.decode("utf-8")
+
+    format_is_cif = is_cif(io.StringIO(content_str))
+    atoms = (
+        parse_cif_atoms(content_str) if format_is_cif else parse_pdb_atoms(content_str)
+    )
+
+    chains, coords = _extract_c1_atoms(atoms, atom_name, model)
+    if len(chains) == 0:
+        return []
+    if len(chains) == 1:
+        return [{str(chains[0])}]
+
+    tree = KDTree(coords)
+    pairs = tree.query_pairs(distance_threshold)
+
+    return _union_find(chains, pairs)
+
+
+def find_na_chain_groups_file(
+    path: str,
+    distance_threshold: float = DEFAULT_DISTANCE_THRESHOLD,
+    atom_name: str = DEFAULT_ATOM_NAME,
+    model: Optional[int] = None,
+) -> List[Set[str]]:
+    """Read a file and find nucleic-acid chain groups.
+
+    Handles ``.gz`` compressed files transparently.
+    """
+    file_handle = handle_input_file(path)
+    content = file_handle.read()
+    file_handle.close()
+    return find_na_chain_groups(
+        content,
+        distance_threshold=distance_threshold,
+        atom_name=atom_name,
+        model=model,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Quickly find which nucleic-acid chains are in contact in a "
+            "PDB or mmCIF file. Uses a KD-tree on C1' atoms (configurable) "
+            "with a distance threshold to group interacting chains."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help=(
+            "Path(s) to PDB or mmCIF file(s) (optionally .gz). "
+            "If omitted, reads paths from stdin (one per line)."
+        ),
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_DISTANCE_THRESHOLD,
+        help=f"Distance threshold in Angstroms (default: {DEFAULT_DISTANCE_THRESHOLD}).",
+    )
+    parser.add_argument(
+        "--atom",
+        type=str,
+        default=DEFAULT_ATOM_NAME,
+        help=f"Representative atom name (default: {DEFAULT_ATOM_NAME!r}).",
+    )
+    parser.add_argument(
+        "--model",
+        type=int,
+        default=None,
+        help="Model number to analyse (default: first model).",
+    )
+    args = parser.parse_args()
+
+    paths = args.paths
+    if not paths:
+        paths = [line.strip() for line in sys.stdin if line.strip()]
+    if not paths:
+        parser.print_help()
+        return
+
+    results: dict[str, Optional[List[List[str]]]] = {}
+    for path in paths:
+        try:
+            groups = find_na_chain_groups_file(
+                path,
+                distance_threshold=args.threshold,
+                atom_name=args.atom,
+                model=args.model,
+            )
+            results[path] = [sorted(g) for g in groups]
+        except Exception as exc:
+            print(f"Warning: failed to process {path}: {exc}", file=sys.stderr)
+            results[path] = None
+
+    if len(results) == 1:
+        single = next(iter(results.values()))
+        print(orjson.dumps(single).decode("utf-8"))
+    else:
+        print(orjson.dumps(results).decode("utf-8"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_chain_groups.py
+++ b/tests/test_chain_groups.py
@@ -1,0 +1,208 @@
+"""Tests for rnapolis.chain_groups."""
+
+import os
+
+import pytest
+
+from rnapolis.chain_groups import find_na_chain_groups
+
+# Minimal PDB with two nucleotide chains far apart (100 A).
+# Each chain has a single adenosine with C1', so no contacts at 15 A.
+# Coordinates are spread far enough that no pair is within threshold.
+_TWO_CHAIN_FAR_PDB = """\
+ATOM      1  P     A A   1       0.000   0.000   0.000  1.00  0.00           P
+ATOM      2  O5'   A A   1       1.500   0.000   0.000  1.00  0.00           O
+ATOM      3  C5'   A A   1       2.500   0.000   0.000  1.00  0.00           C
+ATOM      4  C4'   A A   1       3.000   1.000   0.000  1.00  0.00           C
+ATOM      5  O4'   A A   1       4.000   0.800   0.000  1.00  0.00           O
+ATOM      6  C3'   A A   1       3.500   2.000   0.000  1.00  0.00           C
+ATOM      7  O3'   A A   1       4.500   2.500   0.000  1.00  0.00           O
+ATOM      8  C2'   A A   1       2.800   2.500   1.000  1.00  0.00           C
+ATOM      9  O2'   A A   1       2.500   3.500   1.000  1.00  0.00           O
+ATOM     10  C1'   A A   1       4.200   1.800   0.500  1.00  0.00           C
+ATOM     11  N9    A A   1       5.200   2.500   0.500  1.00  0.00           N
+ATOM     12  C8    A A   1       6.300   2.300   0.500  1.00  0.00           C
+ATOM     13  N7    A A   1       6.500   1.200   0.500  1.00  0.00           N
+ATOM     14  C5    A A   1       5.400   1.100   0.500  1.00  0.00           C
+ATOM     15  C6    A A   1       5.200  -0.200   0.500  1.00  0.00           C
+ATOM     16  N6    A A   1       4.200  -0.800   0.500  1.00  0.00           N
+ATOM     17  N1    A A   1       6.300  -0.800   0.500  1.00  0.00           N
+ATOM     18  C2    A A   1       7.200  -0.200   0.500  1.00  0.00           C
+ATOM     19  N3    A A   1       7.000   1.100   0.500  1.00  0.00           N
+ATOM     20  C4    A A   1       6.000   2.000   0.500  1.00  0.00           C
+ATOM     21  P     G B   1     100.000   0.000   0.000  1.00  0.00           P
+ATOM     22  O5'   G B   1     101.500   0.000   0.000  1.00  0.00           O
+ATOM     23  C5'   G B   1     102.500   0.000   0.000  1.00  0.00           C
+ATOM     24  C4'   G B   1     103.000   1.000   0.000  1.00  0.00           C
+ATOM     25  O4'   G B   1     104.000   0.800   0.000  1.00  0.00           O
+ATOM     26  C3'   G B   1     103.500   2.000   0.000  1.00  0.00           C
+ATOM     27  O3'   G B   1     104.500   2.500   0.000  1.00  0.00           O
+ATOM     28  C2'   G B   1     102.800   2.500   1.000  1.00  0.00           C
+ATOM     29  O2'   G B   1     102.500   3.500   1.000  1.00  0.00           O
+ATOM     30  C1'   G B   1     104.200   1.800   0.500  1.00  0.00           C
+ATOM     31  N9    G B   1     105.200   2.500   0.500  1.00  0.00           N
+ATOM     32  C8    G B   1     106.300   2.300   0.500  1.00  0.00           C
+ATOM     33  N7    G B   1     106.500   1.200   0.500  1.00  0.00           N
+ATOM     34  C5    G B   1     105.400   1.100   0.500  1.00  0.00           C
+ATOM     35  C6    G B   1     105.200  -0.200   0.500  1.00  0.00           C
+ATOM     36  O6    G B   1     104.200  -0.800   0.500  1.00  0.00           O
+ATOM     37  N1    G B   1     106.300  -0.800   0.500  1.00  0.00           N
+ATOM     38  C2    G B   1     107.200  -0.200   0.500  1.00  0.00           C
+ATOM     39  N3    G B   1     107.000   1.100   0.500  1.00  0.00           N
+ATOM     40  C4    G B   1     106.000   2.000   0.500  1.00  0.00           C
+END
+"""
+
+# Two chains close together -- C1' atoms within 10 A of each other.
+_TWO_CHAIN_CLOSE_PDB = """\
+ATOM      1  C1'   A A   1       0.000   0.000   0.000  1.00  0.00           C
+ATOM      2  N9    A A   1       1.500   0.000   0.000  1.00  0.00           N
+ATOM      3  C4    A A   1       2.500   0.500   0.000  1.00  0.00           C
+ATOM      4  C5    A A   1       2.000   1.500   0.000  1.00  0.00           C
+ATOM      5  N7    A A   1       2.800   2.500   0.000  1.00  0.00           N
+ATOM      6  C8    A A   1       1.800   2.200   0.000  1.00  0.00           C
+ATOM      7  N1    A A   1       3.500  -0.500   0.000  1.00  0.00           N
+ATOM      8  C2    A A   1       4.500  -0.200   0.000  1.00  0.00           C
+ATOM      9  N3    A A   1       4.200   1.100   0.000  1.00  0.00           N
+ATOM     10  C6    A A   1       3.200   1.200   0.000  1.00  0.00           C
+ATOM     11  N6    A A   1       3.800   2.200   0.000  1.00  0.00           N
+ATOM     12  C1'   G B   1       8.000   0.000   0.000  1.00  0.00           C
+ATOM     13  N9    G B   1       9.500   0.000   0.000  1.00  0.00           N
+ATOM     14  C4    G B   1      10.500   0.500   0.000  1.00  0.00           C
+ATOM     15  C5    G B   1      10.000   1.500   0.000  1.00  0.00           C
+ATOM     16  N7    G B   1      10.800   2.500   0.000  1.00  0.00           N
+ATOM     17  C8    G B   1       9.800   2.200   0.000  1.00  0.00           C
+ATOM     18  N1    G B   1      11.500  -0.500   0.000  1.00  0.00           N
+ATOM     19  C2    G B   1      12.500  -0.200   0.000  1.00  0.00           C
+ATOM     20  N3    G B   1      12.200   1.100   0.000  1.00  0.00           N
+ATOM     21  C4    G B   1      11.000   1.100   0.000  1.00  0.00           C
+ATOM     22  C6    G B   1      11.200   1.200   0.000  1.00  0.00           C
+ATOM     23  O6    G B   1      11.800   2.200   0.000  1.00  0.00           O
+END
+"""
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.dirname(__file__)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests -- synthetic PDB data
+# ---------------------------------------------------------------------------
+
+
+def test_two_chains_far_apart():
+    """Two chains with C1' atoms 100 A apart should produce two singleton groups."""
+    groups = find_na_chain_groups(_TWO_CHAIN_FAR_PDB)
+    assert len(groups) == 2
+    assert {"A"} in groups
+    assert {"B"} in groups
+
+
+def test_two_chains_close():
+    """Two chains with C1' atoms ~8 A apart should produce one merged group."""
+    groups = find_na_chain_groups(_TWO_CHAIN_CLOSE_PDB)
+    assert len(groups) == 1
+    assert groups[0] == {"A", "B"}
+
+
+def test_large_threshold_merges_distant_chains():
+    """With a very large threshold, even far-apart chains should merge."""
+    groups = find_na_chain_groups(_TWO_CHAIN_FAR_PDB, distance_threshold=200.0)
+    assert len(groups) == 1
+    assert groups[0] == {"A", "B"}
+
+
+def test_custom_atom_name_c5_prime():
+    """Using C5' instead of C1' should still find the same chains."""
+    groups = find_na_chain_groups(_TWO_CHAIN_FAR_PDB, atom_name="C5'")
+    assert len(groups) == 2
+    assert {"A"} in groups
+    assert {"B"} in groups
+
+
+def test_empty_content():
+    """An empty string should return an empty list."""
+    assert find_na_chain_groups("") == []
+
+
+def test_no_c1_atoms():
+    """Content with no C1' atoms should return an empty list."""
+    pdb_no_c1 = """\
+ATOM      1  CA    ALA A   1       0.000   0.000   0.000  1.00  0.00           C
+ATOM      2  N     ALA A   1       1.500   0.000   0.000  1.00  0.00           N
+END
+"""
+    assert find_na_chain_groups(pdb_no_c1) == []
+
+
+def test_single_chain():
+    """A single nucleic-acid chain should produce one singleton group."""
+    single = _TWO_CHAIN_FAR_PDB.replace("B", "A").replace("G A", "G A")
+    groups = find_na_chain_groups(single)
+    assert len(groups) == 1
+    assert groups[0] == {"A"}
+
+
+# ---------------------------------------------------------------------------
+# Integration tests -- real test data
+# ---------------------------------------------------------------------------
+
+
+def test_1a4d_two_interacting_chains(data_dir):
+    """1A4D has two interacting nucleic-acid chains A and B."""
+    cif_path = os.path.join(data_dir, "1A4D_1_A-B.cif")
+    if not os.path.exists(cif_path):
+        pytest.skip(f"Test file not found: {cif_path}")
+
+    with open(cif_path) as f:
+        content = f.read()
+
+    groups = find_na_chain_groups(content)
+    assert len(groups) == 1
+    assert groups[0] == {"A", "B"}
+
+
+def test_1ehz_single_chain(data_dir):
+    """1ehz is a single-chain tRNA structure."""
+    cif_path = os.path.join(data_dir, "1ehz-assembly-1.cif")
+    if not os.path.exists(cif_path):
+        pytest.skip(f"Test file not found: {cif_path}")
+
+    with open(cif_path) as f:
+        content = f.read()
+
+    groups = find_na_chain_groups(content)
+    assert len(groups) == 1
+    assert groups[0] == {"A"}
+
+
+def test_4qln_single_chain_pdb(data_dir):
+    """4qln PDB has a single nucleic-acid chain A."""
+    pdb_path = os.path.join(data_dir, "4qln.pdb")
+    if not os.path.exists(pdb_path):
+        pytest.skip(f"Test file not found: {pdb_path}")
+
+    with open(pdb_path) as f:
+        content = f.read()
+
+    groups = find_na_chain_groups(content)
+    assert len(groups) == 1
+    assert groups[0] == {"A"}
+
+
+def test_6inq_two_chains(data_dir):
+    """6INQ has chains N and T; check if they are grouped correctly."""
+    cif_path = os.path.join(data_dir, "6INQ.cif")
+    if not os.path.exists(cif_path):
+        pytest.skip(f"Test file not found: {cif_path}")
+
+    with open(cif_path) as f:
+        content = f.read()
+
+    groups = find_na_chain_groups(content)
+    chain_set = set()
+    for g in groups:
+        chain_set.update(g)
+    assert chain_set == {"N", "T"}

--- a/uv.lock
+++ b/uv.lock
@@ -2179,7 +2179,7 @@ wheels = [
 
 [[package]]
 name = "rnapolis"
-version = "0.16.9"
+version = "0.16.10"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
Uses a KD-tree built from C1' atoms (one per nucleotide) with a distance threshold (default 15 Å) to group nucleic-acid chains in spatial contact via union-find. Supports batch mode (multiple files or stdin) with JSON output. No Structure/Residue objects built -- operates directly on parsed atom DataFrames for speed.