### PR TITLE
feat: parallelize na-chain-groups with multiprocessing and tqdm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "RNApolis"
-version = "0.16.10"
+version = "0.16.11"
 description = "A Python library containing RNA-related bioinformatics functions and classes"
 authors = [{ name = "Tomasz Zok", email = "tomasz.zok@cs.put.poznan.pl" }]
 readme = "README.md"

--- a/src/rnapolis/chain_groups.py
+++ b/src/rnapolis/chain_groups.py
@@ -15,12 +15,14 @@ harmless), and only one atom per nucleotide is considered.
 import argparse
 import io
 import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from typing import IO, List, Optional, Set, Union
 
 import numpy as np
 import orjson
 import pandas as pd
 from scipy.spatial import KDTree
+from tqdm import tqdm
 
 from rnapolis.parser import is_cif
 from rnapolis.parser_v2 import parse_cif_atoms, parse_pdb_atoms
@@ -244,7 +246,9 @@ def main() -> None:
         return
 
     results: dict[str, Optional[List[List[str]]]] = {}
-    for path in paths:
+
+    if len(paths) == 1:
+        path = paths[0]
         try:
             groups = find_na_chain_groups_file(
                 path,
@@ -256,6 +260,36 @@ def main() -> None:
         except Exception as exc:
             print(f"Warning: failed to process {path}: {exc}", file=sys.stderr)
             results[path] = None
+    else:
+        with ProcessPoolExecutor() as executor:
+            futures = {
+                executor.submit(
+                    find_na_chain_groups_file,
+                    path,
+                    distance_threshold=args.threshold,
+                    atom_name=args.atom,
+                    model=args.model,
+                ): path
+                for path in paths
+            }
+            for future in tqdm(
+                as_completed(futures),
+                total=len(futures),
+                desc="Processing",
+                unit="file",
+            ):
+                path = futures[future]
+                try:
+                    groups = future.result()
+                    results[path] = [sorted(g) for g in groups]
+                except Exception as exc:
+                    print(
+                        f"Warning: failed to process {path}: {exc}",
+                        file=sys.stderr,
+                    )
+                    results[path] = None
+
+        results = dict(sorted(results.items()))
 
     if len(results) == 1:
         single = next(iter(results.values()))

--- a/uv.lock
+++ b/uv.lock
@@ -2214,7 +2214,7 @@ wheels = [
 
 [[package]]
 name = "rnapolis"
-version = "0.16.10"
+version = "0.16.11"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
Batch mode now uses ProcessPoolExecutor (all available CPUs) with a tqdm progress bar. Single-file invocations bypass the pool to avoid overhead. Output ordering is deterministic (sorted by filename).